### PR TITLE
Update version to 2.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ MAINTAINER gijsmolenaar@gmail.com
 
 RUN apt-get update && \
     apt-get install -y \
-        lofar=2.12.1-1trusty \
+        lofar=2.15.0-1trusty \
         && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_REPO=radioastro/lofar:2.12.1
+DOCKER_REPO=radioastro/lofar:2.15.0
 
 .PHONY: build clean
 


### PR DESCRIPTION
It looks like docker-lofar is currently broken because 2.12.1 isn't in the repo any more. This updates to lofar to version 2.15.0
